### PR TITLE
Integrate sound_api submodule, and make recipes configurable per game, but fallback to Minetest Game items otherwise.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "sound_api_core"]
-	path = sound_api_core
-	url = https://github.com/mt-mods/sound_api_core.git

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,7 +1,7 @@
 globals = {
-    "minetest", "basic_materials",
+    "minetest", "basic_materials", "bm",
 }
 
 read_globals = {
-    "default",
+    "default", "bm", "ks_sounds","mcl_sounds","nodes_nature","fl_topsoil","fl_stone","fl_trees",
 }

--- a/README.md
+++ b/README.md
@@ -20,11 +20,3 @@ mod that adds basic material nodes and items
 ### Option 3: use git
 
 * `git clone https://github.com/mt-mods/basic_materials.git`
-* `cd basic_materials`
-* `git submodule init`
-* `git submodule update`
-
-to update please use the following commands starting inside the mod directory
-
-* `git submodule sync`
-* `git submodule update`

--- a/crafts.lua
+++ b/crafts.lua
@@ -106,18 +106,18 @@ minetest.register_craft({
     minetest.register_craft({
         output = "basic_materials:concrete_block 6",
         recipe = {
-            {"group:sand",                "basic_materials:wet_cement", gameconfig_gravel},
+            {"group:sand",                "basic_materials:wet_cement", bm.gameconfig_gravel},
             {"basic_materials:steel_bar", "basic_materials:wet_cement", "basic_materials:steel_bar"},
-            {gameconfig_gravel,            "basic_materials:wet_cement", "group:sand"},
+            {bm.gameconfig_gravel,            "basic_materials:wet_cement", "group:sand"},
         }
     })
 
     minetest.register_craft( {
         output = "basic_materials:motor 2",
         recipe = {
-            { gameconfig_mese_crystal_fragment, "basic_materials:copper_wire", "basic_materials:plastic_sheet" },
-            { gameconfig_copper_ingot,          gameconfig_steel_ingot,         gameconfig_steel_ingot },
-            { gameconfig_mese_crystal_fragment, "basic_materials:copper_wire", "basic_materials:plastic_sheet" }
+            { bm.gameconfig_mese_crystal_fragment, "basic_materials:copper_wire", "basic_materials:plastic_sheet" },
+            { bm.gameconfig_copper_ingot,          bm.gameconfig_steel_ingot,         bm.gameconfig_steel_ingot },
+            { bm.gameconfig_mese_crystal_fragment, "basic_materials:copper_wire", "basic_materials:plastic_sheet" }
         },
         replacements = {
             { "basic_materials:copper_wire", "basic_materials:empty_spool" },
@@ -128,7 +128,7 @@ minetest.register_craft({
     minetest.register_craft( {
         output = "basic_materials:heating_element 2",
         recipe = {
-            { gameconfig_copper_ingot, gameconfig_mese_crystal_fragment, gameconfig_copper_ingot }
+            { bm.gameconfig_copper_ingot, bm.gameconfig_mese_crystal_fragment, bm.gameconfig_copper_ingot }
         },
     })
 
@@ -136,8 +136,8 @@ minetest.register_craft({
         --type = "shapeless",
         output = "basic_materials:energy_crystal_simple 2",
         recipe = {
-            { gameconfig_mese_crystal_fragment, gameconfig_torch, gameconfig_mese_crystal_fragment },
-            { gameconfig_diamond, gameconfig_gold_ingot, gameconfig_diamond }
+            { bm.gameconfig_mese_crystal_fragment, bm.gameconfig_torch, bm.gameconfig_mese_crystal_fragment },
+            { bm.gameconfig_diamond, bm.gameconfig_gold_ingot, bm.gameconfig_diamond }
         },
     })
 
@@ -145,7 +145,7 @@ minetest.register_craft({
         output = "basic_materials:copper_wire 2",
         type = "shapeless",
         recipe = {
-            gameconfig_copper_ingot,
+            bm.gameconfig_copper_ingot,
             "basic_materials:empty_spool",
             "basic_materials:empty_spool",
         },
@@ -155,7 +155,7 @@ minetest.register_craft({
         output = "basic_materials:gold_wire 2",
         type = "shapeless",
         recipe = {
-            gameconfig_gold_ingot,
+            bm.gameconfig_gold_ingot,
             "basic_materials:empty_spool",
             "basic_materials:empty_spool",
         },
@@ -165,7 +165,7 @@ minetest.register_craft({
         output = "basic_materials:steel_wire 2",
         type = "shapeless",
         recipe = {
-            gameconfig_steel_ingot,
+            bm.gameconfig_steel_ingot,
             "basic_materials:empty_spool",
             "basic_materials:empty_spool",
         },
@@ -174,25 +174,25 @@ minetest.register_craft({
     minetest.register_craft( {
         output = "basic_materials:steel_strip 12",
         recipe = {
-            { "", gameconfig_steel_ingot, "" },
-            { gameconfig_steel_ingot, "", "" },
+            { "", bm.gameconfig_steel_ingot, "" },
+            { bm.gameconfig_steel_ingot, "", "" },
         },
     })
 
     minetest.register_craft( {
         output = "basic_materials:copper_strip 12",
         recipe = {
-            { "", gameconfig_copper_ingot, "" },
-            { gameconfig_copper_ingot, "", "" },
+            { "", bm.gameconfig_copper_ingot, "" },
+            { bm.gameconfig_copper_ingot, "", "" },
         },
     })
 
     minetest.register_craft( {
         output = "basic_materials:steel_bar 6",
         recipe = {
-            { "", "", gameconfig_steel_ingot },
-            { "", gameconfig_steel_ingot, "" },
-            { gameconfig_steel_ingot, "", "" },
+            { "", "", bm.gameconfig_steel_ingot },
+            { "", bm.gameconfig_steel_ingot, "" },
+            { bm.gameconfig_steel_ingot, "", "" },
         },
     })
 
@@ -200,26 +200,26 @@ minetest.register_craft({
         output = "basic_materials:padlock 2",
         recipe = {
             { "basic_materials:steel_bar" },
-            { gameconfig_steel_ingot },
-            { gameconfig_steel_ingot },
+            { bm.gameconfig_steel_ingot },
+            { bm.gameconfig_steel_ingot },
         },
     })
 
     minetest.register_craft({
         output = "basic_materials:chainlink_steel 12",
         recipe = {
-            {"", gameconfig_steel_ingot, gameconfig_steel_ingot},
-            { gameconfig_steel_ingot, "", gameconfig_steel_ingot },
-            { gameconfig_steel_ingot, gameconfig_steel_ingot, "" },
+            {"", bm.gameconfig_steel_ingot, bm.gameconfig_steel_ingot},
+            { bm.gameconfig_steel_ingot, "", bm.gameconfig_steel_ingot },
+            { bm.gameconfig_steel_ingot, bm.gameconfig_steel_ingot, "" },
         },
     })
 
     minetest.register_craft( {
         output = "basic_materials:gear_steel 6",
         recipe = {
-            { "", gameconfig_steel_ingot, "" },
-            { gameconfig_steel_ingot,"basic_materials:chainlink_steel", gameconfig_steel_ingot },
-            { "", gameconfig_steel_ingot, "" }
+            { "", bm.gameconfig_steel_ingot, "" },
+            { bm.gameconfig_steel_ingot,"basic_materials:chainlink_steel", bm.gameconfig_steel_ingot },
+            { "", bm.gameconfig_steel_ingot, "" }
         },
     })
 
@@ -228,11 +228,11 @@ minetest.register_craft({
         type = "shapeless",
         output = "basic_materials:terracotta_base 8",
         recipe = {
-            gameconfig_water_bucket,
-            gameconfig_clay_lump,
-            gameconfig_gravel,
+            bm.gameconfig_water_bucket,
+            bm.gameconfig_clay_lump,
+            bm.gameconfig_gravel,
         },
-        replacements = { {gameconfig_water_bucket, gameconfig_empty_bucket}, },
+        replacements = { {bm.gameconfig_water_bucket, bm.gameconfig_empty_bucket}, },
     })
 
 
@@ -240,21 +240,21 @@ minetest.register_craft({
         type = "shapeless",
         output = "basic_materials:wet_cement 3",
         recipe = {
-            gameconfig_dirt,
-            gameconfig_dye_dark_grey,
-            gameconfig_dye_dark_grey,
-            gameconfig_dye_dark_grey,
-            gameconfig_water_bucket
+            bm.gameconfig_dirt,
+            bm.gameconfig_dye_dark_grey,
+            bm.gameconfig_dye_dark_grey,
+            bm.gameconfig_dye_dark_grey,
+            bm.gameconfig_water_bucket
         },
-        replacements = {{gameconfig_water_bucket, gameconfig_empty_bucket},},
+        replacements = {{bm.gameconfig_water_bucket, bm.gameconfig_empty_bucket},},
     })
 
 
     minetest.register_craft( {
         output = "basic_materials:silicon 4",
         recipe = {
-            { gameconfig_sand, gameconfig_sand },
-            { gameconfig_sand, gameconfig_steel_ingot },
+            { bm.gameconfig_sand, bm.gameconfig_sand },
+            { bm.gameconfig_sand, bm.gameconfig_steel_ingot },
         },
     })
 
@@ -262,7 +262,7 @@ minetest.register_craft({
         output = "basic_materials:ic 4",
         recipe = {
             { "basic_materials:silicon", "basic_materials:silicon" },
-            { "basic_materials:silicon", gameconfig_copper_ingot },
+            { "basic_materials:silicon", bm.gameconfig_copper_ingot },
         },
     })
 
@@ -272,9 +272,9 @@ minetest.register_craft({
         minetest.register_craft( {
             output = "basic_materials:brass_ingot 9",
             recipe = {
-            {gameconfig_copper_ingot, gameconfig_tin_ingot, gameconfig_copper_ingot},
-            {gameconfig_gold_ingot, gameconfig_copper_ingot, gameconfig_gold_ingot},
-            {gameconfig_copper_ingot, gameconfig_tin_ingot, gameconfig_copper_ingot},
+            {bm.gameconfig_copper_ingot, bm.gameconfig_tin_ingot, bm.gameconfig_copper_ingot},
+            {bm.gameconfig_gold_ingot, bm.gameconfig_copper_ingot, bm.gameconfig_gold_ingot},
+            {bm.gameconfig_copper_ingot, bm.gameconfig_tin_ingot, bm.gameconfig_copper_ingot},
             },
         })
 
@@ -282,7 +282,7 @@ minetest.register_craft({
             output = "basic_materials:silver_wire 2",
             type = "shapeless",
             recipe = {
-                gameconfig_silver_ingot,
+                bm.gameconfig_silver_ingot,
                 "basic_materials:empty_spool",
                 "basic_materials:empty_spool",
             },
@@ -292,10 +292,11 @@ minetest.register_craft({
             type = "shapeless",
             output = "basic_materials:brass_ingot 3",
             recipe = {
-                gameconfig_copper_ingot,
-                gameconfig_copper_ingot,
+                bm.gameconfig_copper_ingot,
+                bm.gameconfig_copper_ingot,
                 "moreores:silver_ingot",
             },
         })
     end
+
 

--- a/crafts.lua
+++ b/crafts.lua
@@ -9,7 +9,7 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = 'basic_materials:chain_steel 2',
+	output = "basic_materials:chain_steel 2",
 	recipe = {
 		{"basic_materials:chainlink_steel"},
 		{"basic_materials:chainlink_steel"},
@@ -18,7 +18,7 @@ minetest.register_craft({
 })
 
 minetest.register_craft({
-	output = 'basic_materials:chain_brass 2',
+	output = "basic_materials:chain_brass 2",
 	recipe = {
 		{"basic_materials:chainlink_brass"},
 		{"basic_materials:chainlink_brass"},
@@ -102,22 +102,22 @@ minetest.register_craft({
 	burntime = 30,
 })
 
-if minetest.get_modpath("default") then
+
     minetest.register_craft({
-        output = 'basic_materials:concrete_block 6',
+        output = "basic_materials:concrete_block 6",
         recipe = {
-            {'group:sand',                'basic_materials:wet_cement', 'default:gravel'},
-            {'basic_materials:steel_bar', 'basic_materials:wet_cement', 'basic_materials:steel_bar'},
-            {'default:gravel',            'basic_materials:wet_cement', 'group:sand'},
+            {"group:sand",                "basic_materials:wet_cement", gameconfig_gravel},
+            {"basic_materials:steel_bar", "basic_materials:wet_cement", "basic_materials:steel_bar"},
+            {gameconfig_gravel,            "basic_materials:wet_cement", "group:sand"},
         }
     })
 
     minetest.register_craft( {
         output = "basic_materials:motor 2",
         recipe = {
-            { "default:mese_crystal_fragment", "basic_materials:copper_wire", "basic_materials:plastic_sheet" },
-            { "default:copper_ingot",          "default:steel_ingot",         "default:steel_ingot" },
-            { "default:mese_crystal_fragment", "basic_materials:copper_wire", "basic_materials:plastic_sheet" }
+            { gameconfig_mese_crystal_fragment, "basic_materials:copper_wire", "basic_materials:plastic_sheet" },
+            { gameconfig_copper_ingot,          gameconfig_steel_ingot,         gameconfig_steel_ingot },
+            { gameconfig_mese_crystal_fragment, "basic_materials:copper_wire", "basic_materials:plastic_sheet" }
         },
         replacements = {
             { "basic_materials:copper_wire", "basic_materials:empty_spool" },
@@ -128,7 +128,7 @@ if minetest.get_modpath("default") then
     minetest.register_craft( {
         output = "basic_materials:heating_element 2",
         recipe = {
-            { "default:copper_ingot", "default:mese_crystal_fragment", "default:copper_ingot" }
+            { gameconfig_copper_ingot, gameconfig_mese_crystal_fragment, gameconfig_copper_ingot }
         },
     })
 
@@ -136,8 +136,8 @@ if minetest.get_modpath("default") then
         --type = "shapeless",
         output = "basic_materials:energy_crystal_simple 2",
         recipe = {
-            { "default:mese_crystal_fragment", "default:torch", "default:mese_crystal_fragment" },
-            { "default:diamond", "default:gold_ingot", "default:diamond" }
+            { gameconfig_mese_crystal_fragment, gameconfig_torch, gameconfig_mese_crystal_fragment },
+            { gameconfig_diamond, gameconfig_gold_ingot, gameconfig_diamond }
         },
     })
 
@@ -145,7 +145,7 @@ if minetest.get_modpath("default") then
         output = "basic_materials:copper_wire 2",
         type = "shapeless",
         recipe = {
-            "default:copper_ingot",
+            gameconfig_copper_ingot,
             "basic_materials:empty_spool",
             "basic_materials:empty_spool",
         },
@@ -155,7 +155,7 @@ if minetest.get_modpath("default") then
         output = "basic_materials:gold_wire 2",
         type = "shapeless",
         recipe = {
-            "default:gold_ingot",
+            gameconfig_gold_ingot,
             "basic_materials:empty_spool",
             "basic_materials:empty_spool",
         },
@@ -165,7 +165,7 @@ if minetest.get_modpath("default") then
         output = "basic_materials:steel_wire 2",
         type = "shapeless",
         recipe = {
-            "default:steel_ingot",
+            gameconfig_steel_ingot,
             "basic_materials:empty_spool",
             "basic_materials:empty_spool",
         },
@@ -174,25 +174,25 @@ if minetest.get_modpath("default") then
     minetest.register_craft( {
         output = "basic_materials:steel_strip 12",
         recipe = {
-            { "", "default:steel_ingot", "" },
-            { "default:steel_ingot", "", "" },
+            { "", gameconfig_steel_ingot, "" },
+            { gameconfig_steel_ingot, "", "" },
         },
     })
 
     minetest.register_craft( {
         output = "basic_materials:copper_strip 12",
         recipe = {
-            { "", "default:copper_ingot", "" },
-            { "default:copper_ingot", "", "" },
+            { "", gameconfig_copper_ingot, "" },
+            { gameconfig_copper_ingot, "", "" },
         },
     })
 
     minetest.register_craft( {
         output = "basic_materials:steel_bar 6",
         recipe = {
-            { "", "", "default:steel_ingot" },
-            { "", "default:steel_ingot", "" },
-            { "default:steel_ingot", "", "" },
+            { "", "", gameconfig_steel_ingot },
+            { "", gameconfig_steel_ingot, "" },
+            { gameconfig_steel_ingot, "", "" },
         },
     })
 
@@ -200,104 +200,102 @@ if minetest.get_modpath("default") then
         output = "basic_materials:padlock 2",
         recipe = {
             { "basic_materials:steel_bar" },
-            { "default:steel_ingot" },
-            { "default:steel_ingot" },
+            { gameconfig_steel_ingot },
+            { gameconfig_steel_ingot },
         },
     })
 
     minetest.register_craft({
         output = "basic_materials:chainlink_steel 12",
         recipe = {
-            {"", "default:steel_ingot", "default:steel_ingot"},
-            { "default:steel_ingot", "", "default:steel_ingot" },
-            { "default:steel_ingot", "default:steel_ingot", "" },
+            {"", gameconfig_steel_ingot, gameconfig_steel_ingot},
+            { gameconfig_steel_ingot, "", gameconfig_steel_ingot },
+            { gameconfig_steel_ingot, gameconfig_steel_ingot, "" },
         },
     })
 
     minetest.register_craft( {
         output = "basic_materials:gear_steel 6",
         recipe = {
-            { "", "default:steel_ingot", "" },
-            { "default:steel_ingot","basic_materials:chainlink_steel", "default:steel_ingot" },
-            { "", "default:steel_ingot", "" }
+            { "", gameconfig_steel_ingot, "" },
+            { gameconfig_steel_ingot,"basic_materials:chainlink_steel", gameconfig_steel_ingot },
+            { "", gameconfig_steel_ingot, "" }
         },
     })
 
-    if minetest.get_modpath("bucket") then
-        minetest.register_craft( {
-            type = "shapeless",
-            output = "basic_materials:terracotta_base 8",
-            recipe = {
-                "bucket:bucket_water",
-                "default:clay_lump",
-                "default:gravel",
-            },
-            replacements = { {"bucket:bucket_water", "bucket:bucket_empty"}, },
-        })
 
-        if minetest.get_modpath("dye") then
-            minetest.register_craft({
-                type = "shapeless",
-                output = "basic_materials:wet_cement 3",
-                recipe = {
-                    "default:dirt",
-                    "dye:dark_grey",
-                    "dye:dark_grey",
-                    "dye:dark_grey",
-                    "bucket:bucket_water"
-                },
-                replacements = {{'bucket:bucket_water', 'bucket:bucket_empty'},},
-            })
-        end
-    end
+    minetest.register_craft( {
+        type = "shapeless",
+        output = "basic_materials:terracotta_base 8",
+        recipe = {
+            gameconfig_water_bucket,
+            gameconfig_clay_lump,
+            gameconfig_gravel,
+        },
+        replacements = { {gameconfig_water_bucket, gameconfig_empty_bucket}, },
+    })
 
-    if minetest.get_modpath("mesecons_materials") then
-        minetest.register_craft( {
-            output = "mesecons_materials:silicon 4",
-            recipe = {
-                { "default:sand", "default:sand" },
-                { "default:sand", "default:steel_ingot" },
-            },
-        })
 
-        minetest.register_craft( {
-            output = "basic_materials:ic 4",
-            recipe = {
-                { "mesecons_materials:silicon", "mesecons_materials:silicon" },
-                { "mesecons_materials:silicon", "default:copper_ingot" },
-            },
-        })
-    end
+    minetest.register_craft({
+        type = "shapeless",
+        output = "basic_materials:wet_cement 3",
+        recipe = {
+            gameconfig_dirt,
+            gameconfig_dye_dark_grey,
+            gameconfig_dye_dark_grey,
+            gameconfig_dye_dark_grey,
+            gameconfig_water_bucket
+        },
+        replacements = {{gameconfig_water_bucket, gameconfig_empty_bucket},},
+    })
+
+
+    minetest.register_craft( {
+        output = "basic_materials:silicon 4",
+        recipe = {
+            { gameconfig_sand, gameconfig_sand },
+            { gameconfig_sand, gameconfig_steel_ingot },
+        },
+    })
+
+    minetest.register_craft( {
+        output = "basic_materials:ic 4",
+        recipe = {
+            { "basic_materials:silicon", "basic_materials:silicon" },
+            { "basic_materials:silicon", gameconfig_copper_ingot },
+        },
+    })
+
 
     if not minetest.get_modpath("moreores") then
         -- Without moreores, there still should be a way to create brass.
         minetest.register_craft( {
             output = "basic_materials:brass_ingot 9",
             recipe = {
-            {"default:copper_ingot", "default:tin_ingot", "default:copper_ingot"},
-            {"default:gold_ingot", "default:copper_ingot", "default:gold_ingot"},
-            {"default:copper_ingot", "default:tin_ingot", "default:copper_ingot"},
-            },
-        })
-    elseif minetest.get_modpath("moreores") then
-        minetest.register_craft( {
-            output = "basic_materials:silver_wire 2",
-            type = "shapeless",
-            recipe = {
-                "moreores:silver_ingot",
-                "basic_materials:empty_spool",
-                "basic_materials:empty_spool",
+            {gameconfig_copper_ingot, gameconfig_tin_ingot, gameconfig_copper_ingot},
+            {gameconfig_gold_ingot, gameconfig_copper_ingot, gameconfig_gold_ingot},
+            {gameconfig_copper_ingot, gameconfig_tin_ingot, gameconfig_copper_ingot},
             },
         })
 
         minetest.register_craft( {
+            output = "basic_materials:silver_wire 2",
+            type = "shapeless",
+            recipe = {
+                gameconfig_silver_ingot,
+                "basic_materials:empty_spool",
+                "basic_materials:empty_spool",
+            },
+        })
+    elseif minetest.get_modpath("moreores") then
+        minetest.register_craft( {
             type = "shapeless",
             output = "basic_materials:brass_ingot 3",
             recipe = {
-                "default:copper_ingot",
-                "default:copper_ingot",
+                gameconfig_copper_ingot,
+                gameconfig_copper_ingot,
                 "moreores:silver_ingot",
             },
         })
     end
-end
+

--- a/gameconfig.lua
+++ b/gameconfig.lua
@@ -1,0 +1,334 @@
+-- Craft ingredients
+
+
+-- MineClone2 support
+local mod_mcl_core = minetest.get_modpath("mcl_core") ~= nil
+if mod_mcl_core then
+	gameconfig_dirt = "mcl_core:dirt"
+	gameconfig_sand = "mcl_core:sand"
+	gameconfig_gravel = "mcl_core:gravel"
+	gameconfig_steel_ingot = "mcl_core:iron_ingot"
+	gameconfig_gold_ingot = "mcl_core:gold_ingot"
+	gameconfig_mese_crystal_fragment = "mesecons:redstone"
+	gameconfig_torch = "mcl_torches:torch"
+	gameconfig_diamond = "mcl_core:diamond"
+	gameconfig_clay_lump = "mcl_core:clay_lump"
+	gameconfig_water_bucket = "mcl_buckets:bucket_water"
+	gameconfig_empty_bucket = "mcl_buckets:bucket_empty"
+	gameconfig_dye_dark_grey = "mcl_dye:dark_grey"
+	-- No current equivalent so default to iron ingot instead.
+	gameconfig_copper_ingot = "mcl_core:iron_ingot"
+	gameconfig_tin_ingot = "mcl_core:iron_ingot"
+	gameconfig_silver_ingot = "mcl_core:iron_ingot"
+--[[
+elseif
+	gameconfig_dirt = 
+	gameconfig_sand = 
+	gameconfig_gravel = 
+	gameconfig_copper_ingot = 
+	gameconfig_steel_ingot = 
+	gameconfig_silver_ingot = 
+	gameconfig_gold_ingot = 
+	gameconfig_tin_ingot = 
+	gameconfig_mese_crystal_fragment = 
+	gameconfig_torch = 
+	gameconfig_diamond = 
+	gameconfig_clay_lump = 
+	gameconfig_water_bucket = 
+	gameconfig_empty_bucket = 
+	gameconfig_dye_dark_grey = 
+--]]
+else --fallback to Minetest Game's items.
+	gameconfig_dirt = "default:dirt"
+	gameconfig_sand = "default:sand"
+	gameconfig_gravel = "default:gravel"
+	gameconfig_copper_ingot = "default:copper_ingot"
+	gameconfig_steel_ingot = "default:steel_ingot"
+	gameconfig_gold_ingot = "default:gold_ingot"
+	gameconfig_tin_ingot = "default:tin_ingot"
+	gameconfig_mese_crystal_fragment = "default:mese_crystal_fragment"
+	gameconfig_torch = "default:torch"
+	gameconfig_diamond = "default:diamond"
+	gameconfig_clay_lump = "default:clay_lump"
+	gameconfig_water_bucket = "bucket:bucket_water"
+	gameconfig_empty_bucket = "bucket:bucket_empty"
+	gameconfig_dye_dark_grey = "dye:dark_grey"
+	-- No current equivalent so default to copper ingot instead.
+	gameconfig_silver_ingot = "default:copper_ingot"
+end
+
+
+
+
+
+
+-- Sounds
+-- Integrate wsor4035's MIT licensed sound_api
+--[[
+MIT Copyright 2021 wsor4035
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+--]]
+
+local sound_api = {}
+
+--convert some games for api usage
+
+--ks_sounds conversion
+--currently loggy and bedrock are ignored
+local ks = {}
+
+function ks.node_sound_defaults(table)
+	table = table or {}
+	table.footstep = table.footstep or ks_sounds.generalnode_sounds.footstep
+	table.dug = table.dug or ks_sounds.generalnode_sounds.dug
+    table.dig = table.dig or ks_sounds.generalnode_sounds.dig
+	table.place = table.place or ks_sounds.generalnode_sounds.place
+	return table
+end
+
+function ks.node_sound_wood_defaults(table)
+	table = table or {}
+	table.footstep = table.footstep or ks_sounds.woodennode_sounds.footstep
+	table.dug = table.dug or ks_sounds.woodennode_sounds.dug
+    table.dig = table.dig or ks_sounds.woodennode_sounds.dig
+	table.place = table.place or ks_sounds.woodennode_sounds.place
+	ks.node_sound_defaults(table)
+	return table
+end
+
+function ks.node_sound_leaves_defaults(table)
+	table = table or {}
+	table.footstep = table.footstep or ks_sounds.leafynode_sounds.footstep
+	table.dug = table.dug or ks_sounds.leafynode_sounds.dug
+    table.dig = table.dig or ks_sounds.leafynode_sounds.dig
+	table.place = table.place or ks_sounds.leafynode_sounds.place
+	ks.node_sound_defaults(table)
+	return table
+end
+
+function ks.node_sound_snow_defaults(table)
+	table = table or {}
+	table.footstep = table.footstep or ks_sounds.snowynode_sounds.footstep
+	table.dug = table.dug or ks_sounds.snowynode_sounds.dug
+    table.dig = table.dig or ks_sounds.snowynode_sounds.dig
+	table.place = table.place or ks_sounds.snowynode_sounds.place
+	ks.node_sound_defaults(table)
+	return table
+end
+
+
+--api
+function sound_api.node_sound_default(table)
+    if minetest.get_modpath("default") then
+        return default.node_sound_defaults(table)
+    elseif minetest.get_modpath("mcl_sounds") then
+        return mcl_sounds.node_sound_defaults(table)
+    elseif minetest.get_modpath("ks_sounds") then
+        return ks.node_sound_default(table)
+    elseif minetest.get_modpath("nodes_nature") then
+        return nodes_nature.node_sound_default(table)
+    else
+        return table
+    end
+end
+
+function sound_api.node_sound_stone_defaults(table)
+    if minetest.get_modpath("default") then
+        return default.node_sound_stone_defaults(table)
+    elseif minetest.get_modpath("mcl_sounds") then
+        return mcl_sounds.node_sound_stone_defaults(table)
+    elseif minetest.get_modpath("nodes_nature") then
+        return nodes_nature.node_sound_stone_defaults(table)
+    elseif minetest.get_modpath("fl_stone") then
+        return fl_stone.sounds.stone(table)
+    else
+        return table
+    end
+end
+
+function sound_api.node_sound_dirt_defaults(table)
+    if minetest.get_modpath("default") then
+        return default.node_sound_dirt_defaults(table)
+    elseif minetest.get_modpath("mcl_sounds") then
+        return mcl_sounds.node_sound_dirt_defaults(table)
+    elseif minetest.get_modpath("nodes_nature") then
+        return nodes_nature.node_sound_dirt_defaults(table)
+    --s/dirt/grass
+    elseif minetest.get_modpath("fl_topsoil") then
+        return fl_topsoil.sounds.grass(table)
+    else
+        return table
+    end
+end
+
+--return dirt as some games use dirt vs grass
+function sound_api.node_sound_grass_defaults(table)
+    return sound_api.node_sound_dirt_defaults(table)
+end
+
+function sound_api.node_sound_sand_defaults(table)
+    if minetest.get_modpath("default") then
+        return default.node_sound_sand_defaults(table)
+    elseif minetest.get_modpath("mcl_sounds") then
+        return mcl_sounds.node_sound_sand_defaults(table)
+    elseif minetest.get_modpath("nodes_nature") then
+        return nodes_nature.node_sound_sand_defaults(table)
+    elseif minetest.get_modpath("fl_stone") then
+        return fl_stone.sounds.sand(table)
+    else
+        return table
+    end
+end
+
+function sound_api.node_sound_gravel_defaults(table)
+    if minetest.get_modpath("default") then
+        return default.node_sound_gravel_defaults(table)
+    --s/gravel/sand
+    elseif minetest.get_modpath("mcl_sounds") then
+        return mcl_sounds.node_sound_sand_defaults(table)
+    elseif minetest.get_modpath("nodes_nature") then
+        return nodes_nature.node_sound_gravel_defaults(table)
+    elseif minetest.get_modpath("fl_topsoil") then
+        return fl_topsoil.sounds.gravel(table)
+    else
+        return table
+    end
+end
+
+function sound_api.node_sound_wood_defaults(table)
+    if minetest.get_modpath("default") then
+        return default.node_sound_wood_defaults(table)
+    elseif minetest.get_modpath("mcl_sounds") then
+        return mcl_sounds.node_sound_wood_defaults(table)
+    elseif minetest.get_modpath("ks_sounds") then
+        return ks.node_sound_wood_default(table)
+    elseif minetest.get_modpath("nodes_nature") then
+        return nodes_nature.node_sound_wood_defaults(table)
+    elseif minetest.get_modpath("fl_trees") then
+        return fl_trees.sounds.wood(table)
+    else
+        return table
+    end
+end
+
+function sound_api.node_sound_leaves_defaults(table)
+    if minetest.get_modpath("default") then
+        return default.node_sound_leaves_defaults(table)
+    elseif minetest.get_modpath("mcl_sounds") then
+        return mcl_sounds.node_sound_leaves_defaults(table)
+    elseif minetest.get_modpath("ks_sounds") then
+        return ks.node_sound_leaves_default(table)
+    elseif minetest.get_modpath("nodes_nature") then
+        return nodes_nature.node_sound_leaves_defaults(table)
+    else
+        return table
+    end
+end
+
+function sound_api.node_sound_glass_defaults(table)
+    if minetest.get_modpath("default") then
+        return default.node_sound_glass_defaults(table)
+    elseif minetest.get_modpath("mcl_sounds") then
+        return mcl_sounds.node_sound_glass_defaults(table)
+    elseif minetest.get_modpath("nodes_nature") then
+        return nodes_nature.node_sound_glass_defaults(table)
+    else
+        return table
+    end
+end
+
+
+function sound_api.node_sound_ice_defaults(table)
+    if minetest.get_modpath("default") then
+        return default.node_sound_ice_defaults(table)
+    --s/ice/glass
+    elseif minetest.get_modpath("mcl_sounds") then
+        return mcl_sounds.node_sound_glass_defaults(table)
+    --s/ice/glass
+    elseif minetest.get_modpath("nodes_nature") then
+        return nodes_nature.node_sound_glass_defaults(table)
+    else
+        return table
+    end
+end
+
+function sound_api.node_sound_metal_defaults(table)
+    if minetest.get_modpath("default") then
+        return default.node_sound_metal_defaults(table)
+    elseif minetest.get_modpath("mcl_sounds") then
+        return mcl_sounds.node_sound_metal_defaults(table)
+    else
+        return table
+    end
+end
+
+function sound_api.node_sound_water_defaults(table)
+    if minetest.get_modpath("default") then
+        return default.node_sound_water_defaults(table)
+    elseif minetest.get_modpath("mcl_sounds") then
+        return mcl_sounds.node_sound_water_defaults(table)
+    elseif minetest.get_modpath("nodes_nature") then
+        return nodes_nature.node_sound_water_defaults(table)
+    else
+        return table
+    end
+end
+
+function sound_api.node_sound_lava_defaults(table)
+    --s/lava/water
+    if minetest.get_modpath("default") then
+        return default.node_sound_water_defaults(table)
+    elseif minetest.get_modpath("mcl_sounds") then
+        return mcl_sounds.node_sound_lava_defaults(table)
+    --s/lava/water
+    elseif minetest.get_modpath("nodes_nature") then
+        return nodes_nature.node_sound_water_defaults(table)
+    else
+        return table
+    end
+end
+
+function sound_api.node_sound_snow_defaults(table)
+    if minetest.get_modpath("default") then
+        return default.node_sound_snow_defaults(table)
+    elseif minetest.get_modpath("mcl_sounds") then
+        return mcl_sounds.node_sound_snow_defaults(table)
+    elseif minetest.get_modpath("ks_sounds") then
+        return ks.node_sound_snow_default(table)
+    elseif minetest.get_modpath("nodes_nature") then
+        return nodes_nature.node_sound_snow_defaults(table)
+    elseif minetest.get_modpath("fl_topsoil") then
+        return fl_topsoil.sounds.snow(table)
+    else
+        return table
+    end
+end
+
+function sound_api.node_sound_wool_defaults(table)
+    --s/wool/default
+    if minetest.get_modpath("default") then
+        return default.node_sound_defaults(table)
+    elseif minetest.get_modpath("mcl_sounds") then
+        return mcl_sounds.node_sound_wool_defaults(table)
+    else
+        return table
+    end
+end
+
+return sound_api

--- a/gameconfig.lua
+++ b/gameconfig.lua
@@ -1,65 +1,44 @@
 -- Craft ingredients
 
 
+bm = {}
 -- MineClone2 support
 local mod_mcl_core = minetest.get_modpath("mcl_core") ~= nil
 if mod_mcl_core then
-	gameconfig_dirt = "mcl_core:dirt"
-	gameconfig_sand = "mcl_core:sand"
-	gameconfig_gravel = "mcl_core:gravel"
-	gameconfig_steel_ingot = "mcl_core:iron_ingot"
-	gameconfig_gold_ingot = "mcl_core:gold_ingot"
-	gameconfig_mese_crystal_fragment = "mesecons:redstone"
-	gameconfig_torch = "mcl_torches:torch"
-	gameconfig_diamond = "mcl_core:diamond"
-	gameconfig_clay_lump = "mcl_core:clay_lump"
-	gameconfig_water_bucket = "mcl_buckets:bucket_water"
-	gameconfig_empty_bucket = "mcl_buckets:bucket_empty"
-	gameconfig_dye_dark_grey = "mcl_dye:dark_grey"
+	bm.gameconfig_dirt = "mcl_core:dirt"
+	bm.gameconfig_sand = "mcl_core:sand"
+	bm.gameconfig_gravel = "mcl_core:gravel"
+	bm.gameconfig_steel_ingot = "mcl_core:iron_ingot"
+	bm.gameconfig_gold_ingot = "mcl_core:gold_ingot"
+	bm.gameconfig_mese_crystal_fragment = "mesecons:redstone"
+	bm.gameconfig_torch = "mcl_torches:torch"
+	bm.gameconfig_diamond = "mcl_core:diamond"
+	bm.gameconfig_clay_lump = "mcl_core:clay_lump"
+	bm.gameconfig_water_bucket = "mcl_buckets:bucket_water"
+	bm.gameconfig_empty_bucket = "mcl_buckets:bucket_empty"
+	bm.gameconfig_dye_dark_grey = "mcl_dye:dark_grey"
 	-- No current equivalent so default to iron ingot instead.
-	gameconfig_copper_ingot = "mcl_core:iron_ingot"
-	gameconfig_tin_ingot = "mcl_core:iron_ingot"
-	gameconfig_silver_ingot = "mcl_core:iron_ingot"
---[[
-elseif
-	gameconfig_dirt = 
-	gameconfig_sand = 
-	gameconfig_gravel = 
-	gameconfig_copper_ingot = 
-	gameconfig_steel_ingot = 
-	gameconfig_silver_ingot = 
-	gameconfig_gold_ingot = 
-	gameconfig_tin_ingot = 
-	gameconfig_mese_crystal_fragment = 
-	gameconfig_torch = 
-	gameconfig_diamond = 
-	gameconfig_clay_lump = 
-	gameconfig_water_bucket = 
-	gameconfig_empty_bucket = 
-	gameconfig_dye_dark_grey = 
---]]
+	bm.gameconfig_copper_ingot = "mcl_core:iron_ingot"
+	bm.gameconfig_tin_ingot = "mcl_core:iron_ingot"
+	bm.gameconfig_silver_ingot = "mcl_core:iron_ingot"
 else --fallback to Minetest Game's items.
-	gameconfig_dirt = "default:dirt"
-	gameconfig_sand = "default:sand"
-	gameconfig_gravel = "default:gravel"
-	gameconfig_copper_ingot = "default:copper_ingot"
-	gameconfig_steel_ingot = "default:steel_ingot"
-	gameconfig_gold_ingot = "default:gold_ingot"
-	gameconfig_tin_ingot = "default:tin_ingot"
-	gameconfig_mese_crystal_fragment = "default:mese_crystal_fragment"
-	gameconfig_torch = "default:torch"
-	gameconfig_diamond = "default:diamond"
-	gameconfig_clay_lump = "default:clay_lump"
-	gameconfig_water_bucket = "bucket:bucket_water"
-	gameconfig_empty_bucket = "bucket:bucket_empty"
-	gameconfig_dye_dark_grey = "dye:dark_grey"
+	bm.gameconfig_dirt = "default:dirt"
+	bm.gameconfig_sand = "default:sand"
+	bm.gameconfig_gravel = "default:gravel"
+	bm.gameconfig_copper_ingot = "default:copper_ingot"
+	bm.gameconfig_steel_ingot = "default:steel_ingot"
+	bm.gameconfig_gold_ingot = "default:gold_ingot"
+	bm.gameconfig_tin_ingot = "default:tin_ingot"
+	bm.gameconfig_mese_crystal_fragment = "default:mese_crystal_fragment"
+	bm.gameconfig_torch = "default:torch"
+	bm.gameconfig_diamond = "default:diamond"
+	bm.gameconfig_clay_lump = "default:clay_lump"
+	bm.gameconfig_water_bucket = "bucket:bucket_water"
+	bm.gameconfig_empty_bucket = "bucket:bucket_empty"
+	bm.gameconfig_dye_dark_grey = "dye:dark_grey"
 	-- No current equivalent so default to copper ingot instead.
-	gameconfig_silver_ingot = "default:copper_ingot"
+	bm.gameconfig_silver_ingot = "default:copper_ingot"
 end
-
-
-
-
 
 
 -- Sounds

--- a/nodes.lua
+++ b/nodes.lua
@@ -1,6 +1,7 @@
 local S = minetest.get_translator("basic_materials")
-local sound_api = dofile(basic_materials.modpath .. "/sound_api_core/init.lua")
+local sound_api = dofile(basic_materials.modpath .. "/gameconfig.lua")
 local chains_sbox = {type = "fixed",fixed = { -0.1, -0.5, -0.1, 0.1, 0.5, 0.1 }}
+
 
 minetest.register_node("basic_materials:cement_block", {
 	description = S("Cement"),


### PR DESCRIPTION
Basically, title.
This is to fix: https://github.com/mt-mods/basic_materials/issues/4

Respectfully, adding a submodule for sounds; for 3 nodes is a bit extreme.
While the goal of making 'basic_materials' game agnostic is a good idea. There are still 57 instances of "default:" in the "crafts.lua" file.

So, I've integrated the sound_api, and added a gameconfig section for recipe ingredients as well.
I added recipe support for MineClone2, and fallback to Minetest Game if MCL2 is not present.
But, this can obviously be expanded in the future.
