### PR TITLE
Add mcl_copper support

### DIFF
--- a/crafts.lua
+++ b/crafts.lua
@@ -54,6 +54,9 @@ if minetest.get_modpath("mcl_core") then
 		silver_ingot = "mcl_core:iron_ingot",
 		silicon = "mesecons_materials:silicon",
 	}
+	if minetest.get_modpath("mcl_copper") then
+		materials.copper_ingot = "mcl_copper:copper_ingot"
+	end
 elseif minetest.get_modpath("fl_ores") and minetest.get_modpath("fl_stone") then
 	materials = {
 		dirt = "fl_topsoil:dirt",

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,3 @@
 name = basic_materials
-optional_depends = moreores, default, mesecons_materials, dye, bucket, fl_stone, fl_trees, mcl_sounds, hades_core, hades_sounds, hades_materials, hades_dye, hades_bucket, hades_extraores, hades_mesecons_materials, aloz, rp_crafting
+optional_depends = moreores, default, mesecons_materials, dye, bucket, fl_stone, fl_trees, mcl_sounds, hades_core, hades_sounds, hades_materials, hades_dye, hades_bucket, hades_extraores, hades_mesecons_materials, aloz, rp_crafting, mcl_core
 min_minetest_version = 5.2.0

--- a/mod.conf
+++ b/mod.conf
@@ -1,3 +1,3 @@
 name = basic_materials
-optional_depends = moreores, default, mesecons_materials, dye, bucket, fl_stone, fl_trees, mcl_sounds, hades_core, hades_sounds, hades_materials, hades_dye, hades_bucket, hades_extraores, hades_mesecons_materials, aloz, rp_crafting, mcl_core
+optional_depends = moreores, default, mesecons_materials, dye, bucket, fl_stone, fl_trees, mcl_sounds, hades_core, hades_sounds, hades_materials, hades_dye, hades_bucket, hades_extraores, hades_mesecons_materials, aloz, rp_crafting, mcl_core, mcl_copper
 min_minetest_version = 5.2.0


### PR DESCRIPTION
recent versions of MineClone2 and similar have copper now, use it instead of faking copper with iron when mcl_copper is available.